### PR TITLE
feat: isHighlighted toggle for events, fix update version/speaker bugs

### DIFF
--- a/src/modules/event/entities/event.entity.ts
+++ b/src/modules/event/entities/event.entity.ts
@@ -59,7 +59,7 @@ export class Event extends BaseEntity {
       flagshipEvent: FlagshipEventVersion;
 
       @Column({ name: 'speaker_id', type: 'varchar', length: 36, nullable: true })
-      speakerId: string;
+      speakerId: string | null;
 
       @ManyToOne(() => Speaker, { onDelete: 'RESTRICT' })
       @JoinColumn({ name: 'speaker_id' })

--- a/src/modules/event/services/event.service.ts
+++ b/src/modules/event/services/event.service.ts
@@ -169,6 +169,7 @@ export class EventService {
                         createdAt: true,
                         updatedAt: true,
                         displayOrder: true,
+                        isHighlighted: true,
                         flagshipEvent: {
                               id: true,
                               version_name: true,
@@ -200,6 +201,10 @@ export class EventService {
             if (!event) {
                   throw new AppError('Event not found', 404);
             }
+
+            const resolvedVersionId = data.versionId ?? event.versionId;
+            const resolvedCategoryId = data.categoryId ?? event.categoryId;
+
             if (data.versionId) {
                   const versionExists = await this.versionRepository
                         .findOne({ where: { id: data.versionId } });
@@ -207,7 +212,7 @@ export class EventService {
                         throw new AppError('Flagship event version not found', 404);
                   }
                   if (versionExists.status === EventVersionStatus.ARCHIVED) {
-                        throw new AppError('Cannot update team members for an archived flagship event version', 400);
+                        throw new AppError('Cannot update events for an archived flagship event version', 400);
                   }
             }
             if (data.categoryId) {
@@ -221,38 +226,49 @@ export class EventService {
                   }
             }
             if (data.speakerId) {
-                  const speaker = await this.speakerRepository.findOne({ where: { id: data.speakerId, versionId: data.versionId || event.versionId } });
+                  const speaker = await this.speakerRepository.findOne({ where: { id: data.speakerId, versionId: resolvedVersionId } });
                   if (!speaker) {
                         throw new AppError("Speaker not found in this version", 404);
                   }
             }
-
             if (data.displayOrder) {
-                  const targetCategoryId = data.categoryId || event.categoryId;
                   const existingOrder = await this.eventRepository.findOne({
-                        where: {
-                              categoryId: targetCategoryId,
-                              displayOrder: data.displayOrder
-                        }
+                        where: { categoryId: resolvedCategoryId, displayOrder: data.displayOrder }
                   });
-
-                  // If found another event with same order
                   if (existingOrder && existingOrder.id !== id) {
                         throw new AppError(`Display order ${data.displayOrder} is already taken in this category`, 400);
                   }
             }
 
-            const updatedEvent = await this.eventRepository.save({
-                  ...event,
-                  ...data,
-                  versionId: data.versionId || event.versionId,
-                  categoryId: data.categoryId || event.categoryId,
-                  speakerId: data.speakerId || event.speakerId,
-                  fee: data.fee === null ? "" : (data.fee === undefined ? event.fee : data.fee),
+            // Use update() instead of save() to avoid TypeORM merging loaded relation
+            // objects (flagshipEvent, category, speaker) back over the FK columns we
+            // just changed — that was silently reverting versionId/categoryId.
+            await this.eventRepository.update(id, {
+                  ...(data.title !== undefined && { title: data.title }),
+                  ...(data.subtitle !== undefined && { subtitle: data.subtitle }),
+                  ...(data.description !== undefined && { description: data.description }),
+                  ...(data.startTime !== undefined && { startTime: data.startTime }),
+                  ...(data.endTime !== undefined && { endTime: data.endTime }),
+                  ...(data.date !== undefined && { date: data.date }),
+                  versionId: resolvedVersionId,
+                  categoryId: resolvedCategoryId,
+                  // speakerId undefined means the form sent "" which Zod converted to undefined
+                  // (the form always submits this field). null clears it in the DB.
+                  speakerId: data.speakerId || null,
+                  ...(data.totalSeats !== undefined && { totalSeats: data.totalSeats }),
+                  ...(data.feeType !== undefined && { feeType: data.feeType }),
+                  ...(data.fee !== undefined && { fee: data.fee === null ? "" : data.fee }),
+                  ...(data.location !== undefined && { location: data.location }),
+                  ...(data.status !== undefined && { status: data.status }),
+                  ...(data.registrationDeadline !== undefined && { registrationDeadline: data.registrationDeadline }),
+                  ...(data.displayOrder !== undefined && { displayOrder: data.displayOrder }),
+                  ...(data.isHighlighted !== undefined && { isHighlighted: data.isHighlighted }),
+                  ...(data.imagePath !== undefined && { imagePath: data.imagePath }),
+                  ...(data.imageUrl !== undefined && { imageUrl: data.imageUrl }),
                   modifiedById: userId,
             });
 
-            return updatedEvent;
+            return await this.findById(id);
       }
 
       async findByHighlighted(query: any) {

--- a/src/modules/event/validators/event.validator.ts
+++ b/src/modules/event/validators/event.validator.ts
@@ -34,6 +34,9 @@ export const baseEventSchema = z.object({
     (val) => (typeof val === "string" ? Number(val) : val),
     z.number().int().min(1),
   ),
+  isHighlighted: z
+    .preprocess((v) => v === "true" || v === true, z.boolean())
+    .optional(),
 });
 
 export const createEventSchema = baseEventSchema.superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary

- Add `isHighlighted` field to event entity, validator, and API (create & update)
- Fix event update silently reverting `versionId`/`categoryId` — was caused by TypeORM merging loaded relation objects back over FK columns when using `save()`; switched to `repository.update()` to write only columns
- Fix speaker not clearing when version is changed — `speakerId: "" → undefined` (Zod preprocess) was falling back to the old speaker via `|| event.speakerId`; now saves `null` to DB
- Fix `speakerId` entity type to `string | null` to match the `nullable: true` column
- Add `isHighlighted` to `findById` select so it is returned by the API

## Test plan

- [ ] Create event with `isHighlighted = true` — verify field is saved
- [ ] Edit event and change version — verify new version is persisted, not the old one
- [ ] Edit event and clear speaker — verify speaker is cleared (null) in DB
- [ ] Edit event and change speaker to one from a different version — verify validation error
- [ ] Verify `GET /events/:id` returns `isHighlighted` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)