### PR TITLE
Landing highlights: only include events flagged as highlighted

### DIFF
--- a/src/modules/content/services/content.service.ts
+++ b/src/modules/content/services/content.service.ts
@@ -88,10 +88,11 @@ export class ContentService {
       ? (await this.faqService.findAll({ versionId, limit: ALL })).items
       : undefined;
 
-    // Highlights are the published events for this edition; drafts/archived
-    // never reach the public landing page.
+    // Highlights are the published events explicitly flagged as highlighted
+    // for this edition;If none are highlighted the frontend hides the
+    // whole "Event Overview" section.
     const highlights = (events.items ?? []).filter(
-      (e: any) => e.status === EventStatus.PUBLISHED,
+      (e: any) => e.status === EventStatus.PUBLISHED && e.isHighlighted === true,
     );
 
     return {


### PR DESCRIPTION
Highlights on the public landing page now require isHighlighted=true in addition to PUBLISHED status; when none are flagged the frontend hides the whole section.